### PR TITLE
Refund magic on failed card play or ability

### DIFF
--- a/minion.cc
+++ b/minion.cc
@@ -44,15 +44,31 @@ void Minion::attack(Minion* target) {
 void Minion::useAbility(Player* p) {
     if (!getAbility()) throw std::runtime_error("Minion has no ability.");
     spendAction();
-    p->spendMagic(getAbilityCost());
-    getAbility()->apply(p, nullptr, -1);
+    int oldMagic = p->getMagic();
+    try {
+        p->spendMagic(getAbilityCost());
+        getAbility()->apply(p, nullptr, -1);
+    } catch (...) {
+        if (p->getMagic() < oldMagic) {
+            p->gainMagic(oldMagic - p->getMagic());
+        }
+        throw;
+    }
 }
 
 void Minion::useAbility(Player* p, Player* t, int i) {
     if (!getAbility()) throw std::runtime_error("Minion has no ability.");
     spendAction();
-    p->spendMagic(getAbilityCost());
-    getAbility()->apply(p, t, i);
+    int oldMagic = p->getMagic();
+    try {
+        p->spendMagic(getAbilityCost());
+        getAbility()->apply(p, t, i);
+    } catch (...) {
+        if (p->getMagic() < oldMagic) {
+            p->gainMagic(oldMagic - p->getMagic());
+        }
+        throw;
+    }
 }
 
 void Minion::useTrigger(TriggerType type, std::shared_ptr<Minion> target) {


### PR DESCRIPTION
## Summary
- Restore player's magic if playing a card throws an error, both with and without a target
- Refund magic when a minion ability fails to resolve

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689c17b4b86c8332b92fdeaee66b32ee